### PR TITLE
Add follow-up question suggestions

### DIFF
--- a/src/app/api/chat/index+api.ts
+++ b/src/app/api/chat/index+api.ts
@@ -26,9 +26,34 @@ export async function POST(request: Request) {
       ...(previousResponseId && { previous_response_id: previousResponseId }),
     });
 
+    let relatedQuestions: string[] | undefined = undefined;
+    try {
+      const questionsCompletion = await openai.chat.completions.create({
+        model: 'gpt-4.1',
+        messages: [
+          {
+            role: 'user',
+            content:
+              `Provide 3 advanced follow-up questions related to: ${message}. ` +
+              'Respond in JSON format as { "questions": ["q1","q2","q3"] }.',
+          },
+        ],
+        response_format: { type: 'json_object' },
+      });
+      const parsed = JSON.parse(
+        questionsCompletion.choices[0].message.content || '{}'
+      );
+      if (Array.isArray(parsed.questions)) {
+        relatedQuestions = parsed.questions;
+      }
+    } catch (err) {
+      console.error('Failed to generate related questions:', err);
+    }
+
     return Response.json({
       responseMessage: response.output_text,
       responseId: response.id,
+      ...(relatedQuestions && { relatedQuestions }),
     });
   } catch (error) {
     console.error('OpenAI error:', error);

--- a/src/app/api/chat/speech+api.ts
+++ b/src/app/api/chat/speech+api.ts
@@ -21,10 +21,35 @@ export async function POST(request: Request) {
       ...(previousResponseId && { previous_response_id: previousResponseId }),
     });
 
+    let relatedQuestions: string[] | undefined = undefined;
+    try {
+      const questionsCompletion = await openai.chat.completions.create({
+        model: 'gpt-4.1',
+        messages: [
+          {
+            role: 'user',
+            content:
+              `Provide 3 advanced follow-up questions related to: ${transcription.text}. ` +
+              'Respond in JSON format as { "questions": ["q1","q2","q3"] }.',
+          },
+        ],
+        response_format: { type: 'json_object' },
+      });
+      const parsed = JSON.parse(
+        questionsCompletion.choices[0].message.content || '{}'
+      );
+      if (Array.isArray(parsed.questions)) {
+        relatedQuestions = parsed.questions;
+      }
+    } catch (err) {
+      console.error('Failed to generate related questions:', err);
+    }
+
     return Response.json({
       responseId: response.id,
       responseMessage: response.output_text,
       transcribedMessage: transcription.text,
+      ...(relatedQuestions && { relatedQuestions }),
     });
   } catch (error) {
     console.log(error);

--- a/src/app/chat/[id].tsx
+++ b/src/app/chat/[id].tsx
@@ -29,6 +29,10 @@ export default function ChatScreen() {
 
   const addNewMessage = useChatStore((state) => state.addNewMessage);
 
+  const handleQuestionPress = async (question: string) => {
+    await handleSend(question, null, false, null);
+  };
+
   useEffect(() => {
     const timeout = setTimeout(() => {
       flatListRef.current?.scrollToEnd({ animated: true });
@@ -80,6 +84,7 @@ export default function ChatScreen() {
         message: data.responseMessage,
         responseId: data.responseId,
         image: data.image,
+        relatedQuestions: data.relatedQuestions,
         role: 'assistant' as const,
       };
 
@@ -104,7 +109,12 @@ export default function ChatScreen() {
       <FlatList
         ref={flatListRef}
         data={chat.messages}
-        renderItem={({ item }) => <MessageListItem messageItem={item} />}
+        renderItem={({ item }) => (
+          <MessageListItem
+            messageItem={item}
+            onQuestionPress={handleQuestionPress}
+          />
+        )}
         ListFooterComponent={() =>
           isWaitingForResponse && (
             <Text className='text-gray-400 px-6 mb-4 animate-pulse'>

--- a/src/app/index.tsx
+++ b/src/app/index.tsx
@@ -56,6 +56,7 @@ export default function HomeScreen() {
         message: data.responseMessage,
         responseId: data.responseId,
         image: data.image,
+        relatedQuestions: data.relatedQuestions,
         role: 'assistant' as const,
       };
 

--- a/src/components/MessageListItem.tsx
+++ b/src/components/MessageListItem.tsx
@@ -1,14 +1,18 @@
-import { Text, View, Image } from 'react-native';
+import { Text, View, Image, Pressable } from 'react-native';
 import Markdown from 'react-native-markdown-display';
 import { Message } from '@/types/types';
 import { markdownStyles } from '@/utils/markdown';
 
 interface MessageListItemProps {
   messageItem: Message;
+  onQuestionPress?: (question: string) => void;
 }
 
-export default function MessageListItem({ messageItem }: MessageListItemProps) {
-  const { message, role, image } = messageItem;
+export default function MessageListItem({
+  messageItem,
+  onQuestionPress,
+}: MessageListItemProps) {
+  const { message, role, image, relatedQuestions } = messageItem;
   const isUser = role === 'user';
 
   return (
@@ -32,6 +36,19 @@ export default function MessageListItem({ messageItem }: MessageListItemProps) {
           <Markdown style={markdownStyles}>{message}</Markdown>
         </View>
       )}
+      {!isUser && relatedQuestions?.length ? (
+        <View className='mt-2 w-full max-w-[80%] space-y-1'>
+          {relatedQuestions.map((q, idx) => (
+            <Pressable
+              key={idx}
+              onPress={() => onQuestionPress && onQuestionPress(q)}
+              className='bg-[#262626] rounded-lg p-2'
+            >
+              <Text className='text-gray-300 text-sm'>{q}</Text>
+            </Pressable>
+          ))}
+        </View>
+      ) : null}
     </View>
   );
 }

--- a/src/services/chatService.ts
+++ b/src/services/chatService.ts
@@ -1,4 +1,12 @@
-export async function createAIImage(prompt: string) {
+export interface ChatResponse {
+  responseMessage: string;
+  responseId: string;
+  image?: string;
+  transcribedMessage?: string;
+  relatedQuestions?: string[];
+}
+
+export async function createAIImage(prompt: string): Promise<{ image: string }> {
   const res = await fetch('/api/chat/createImage', {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
@@ -14,7 +22,7 @@ export const getTextResponse = async (
   message: string,
   imageBase64: string | null,
   previousResponseId?: string
-) => {
+): Promise<ChatResponse> => {
   const res = await fetch('/api/chat', {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
@@ -23,13 +31,13 @@ export const getTextResponse = async (
 
   const data = await res.json();
   if (!res.ok) throw new Error(data.error);
-  return data;
+  return data as ChatResponse;
 };
 
 export const getSpeechResponse = async (
   audioBase64: string,
   previousResponseId?: string
-) => {
+): Promise<ChatResponse> => {
   const res = await fetch('/api/chat/speech', {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
@@ -38,5 +46,5 @@ export const getSpeechResponse = async (
 
   const data = await res.json();
   if (!res.ok) throw new Error(data.error);
-  return data;
+  return data as ChatResponse;
 };

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -4,6 +4,7 @@ export interface Message {
   message?: string;
   responseId?: string;
   image?: string;
+  relatedQuestions?: string[];
 }
 
 export interface Chat {


### PR DESCRIPTION
## Summary
- extend `Message` model with `relatedQuestions`
- generate additional questions in text and speech API routes
- return related questions in `chatService`
- store and display questions in the chat view
- allow tapping a question to resend it

## Testing
- `tsc -p tsconfig.json` *(fails: cannot find modules)*

------
https://chatgpt.com/codex/tasks/task_e_68466518efa483298ab2cd214463cd2b